### PR TITLE
Initialize capsule-revnet project with encryption demo

### DIFF
--- a/capsule-revnet/README.md
+++ b/capsule-revnet/README.md
@@ -1,0 +1,10 @@
+# capsule-revnet
+
+Lock football match capsules with Revnet Multiterminal. This project shows a minimal Tiny Capsule and Revnet envelope along with simple encryption utilities.
+
+## Quickstart
+
+```bash
+npm install
+npm run dev
+```

--- a/capsule-revnet/package.json
+++ b/capsule-revnet/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "capsule-revnet",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.2",
+    "zod": "^3.22.2",
+    "viem": "^1.21.0",
+    "jose": "^5.2.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.2"
+  }
+}

--- a/capsule-revnet/src/client.ts
+++ b/capsule-revnet/src/client.ts
@@ -1,0 +1,14 @@
+import { WalletClient, erc20Abi } from "viem";
+import { TinyEnvelope } from "./envelope.tiny";
+
+// Stub for unlocking a Revnet capsule using a wallet
+export async function unlockRevnetCapsule(
+  wallet: WalletClient,
+  env: TinyEnvelope
+) {
+  if (!("r" in env)) return;
+  // Approve USDC to terminal
+  // await wallet.writeContract({ address: "USDC", abi: erc20Abi, functionName: "approve", args: ["TERMINAL", BigInt(env.r.price)] });
+  // Call pay on Multiterminal
+  // await wallet.writeContract({ address: "MULTITERMINAL", abi: [], functionName: "pay", args: [env.r.payTo] });
+}

--- a/capsule-revnet/src/decrypt.ts
+++ b/capsule-revnet/src/decrypt.ts
@@ -1,0 +1,16 @@
+import { compactDecrypt, importJWK, JWK } from "jose";
+import { TinyEnvelope } from "./envelope.tiny";
+import { TinyMatchCapsule, TinyMatchCapsuleSchema } from "./match.tiny";
+
+export async function decryptCapsule(
+  envelope: TinyEnvelope,
+  privJwk: JWK
+): Promise<TinyMatchCapsule> {
+  if (!("e" in envelope)) {
+    throw new Error("Envelope is not encrypted");
+  }
+  const key = await importJWK(privJwk, "RSA-OAEP-256");
+  const { plaintext } = await compactDecrypt(envelope.e, key);
+  const capsule = JSON.parse(new TextDecoder().decode(plaintext));
+  return TinyMatchCapsuleSchema.parse(capsule);
+}

--- a/capsule-revnet/src/encrypt.ts
+++ b/capsule-revnet/src/encrypt.ts
@@ -1,0 +1,18 @@
+import { CompactEncrypt, importJWK, JWK } from "jose";
+import { TinyEnvelope } from "./envelope.tiny";
+import { TinyMatchCapsule } from "./match.tiny";
+
+export async function encryptCapsule(
+  capsule: TinyMatchCapsule,
+  recipientJwk: JWK
+): Promise<TinyEnvelope> {
+  const key = await importJWK(recipientJwk, "RSA-OAEP-256");
+  const plaintext = new TextEncoder().encode(JSON.stringify(capsule));
+  const jwe = await new CompactEncrypt(plaintext)
+    .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+    .encrypt(key);
+  return {
+    e: jwe,
+    r: { price: "0", payTo: "revnet" }
+  };
+}

--- a/capsule-revnet/src/envelope.tiny.ts
+++ b/capsule-revnet/src/envelope.tiny.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const TinyJWE = z.string();
+export type TinyJWE = z.infer<typeof TinyJWE>;
+
+export const TinyRevnet402 = z.object({
+  price: z.string(),
+  payTo: z.string()
+});
+export type TinyRevnet402 = z.infer<typeof TinyRevnet402>;
+
+export const TinyEnvelope = z.union([
+  // cleartext capsule
+  z.object({ c: z.any() }),
+  // encrypted capsule with Revnet payment info
+  z.object({ e: TinyJWE, r: TinyRevnet402 })
+]);
+export type TinyEnvelope = z.infer<typeof TinyEnvelope>;

--- a/capsule-revnet/src/index.ts
+++ b/capsule-revnet/src/index.ts
@@ -1,0 +1,12 @@
+import { sampleCapsule } from "./match.tiny";
+import { encryptCapsule } from "./encrypt";
+import { generateKeyPair, exportJWK } from "jose";
+
+async function main() {
+  const { publicKey } = await generateKeyPair("RSA-OAEP");
+  const pubJwk = await exportJWK(publicKey);
+  const env = await encryptCapsule(sampleCapsule, pubJwk);
+  console.log("Encrypted envelope:", env);
+}
+
+main();

--- a/capsule-revnet/src/match.tiny.ts
+++ b/capsule-revnet/src/match.tiny.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const TinyMatchCapsuleSchema = z.object({
+  schema: z.literal("tiny.match"),
+  id: z.string(),
+  teams: z.tuple([z.string(), z.string()]),
+  score: z.tuple([z.number(), z.number()]),
+  timeline: z.array(z.string())
+});
+
+export type TinyMatchCapsule = z.infer<typeof TinyMatchCapsuleSchema>;
+
+export const sampleCapsule: TinyMatchCapsule = {
+  schema: "tiny.match",
+  id: "match-1",
+  teams: ["AFC", "BFC"],
+  score: [1, 0],
+  timeline: ["00:00 Kickoff", "45:00 Goal by AFC"]
+};

--- a/capsule-revnet/src/server.ts
+++ b/capsule-revnet/src/server.ts
@@ -1,0 +1,14 @@
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+app.post("/grant", (req, res) => {
+  const { chainId, txHash, buyerPubKeyJwk } = req.body;
+  console.log("grant request", chainId, txHash, buyerPubKeyJwk);
+  res.json({ e: "dummy.jwe" });
+});
+
+app.listen(3000, () => {
+  console.log("server listening on port 3000");
+});

--- a/capsule-revnet/tsconfig.json
+++ b/capsule-revnet/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold capsule-revnet TypeScript project with minimal Tiny Capsule and Revnet envelope schemas
- add encryption/decryption helpers and express server stub
- document quickstart instructions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fexpress)*
- `npm test` *(fails: Cannot find module 'viem'...)*
- `npm run dev` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b297fa08832e9d6bc75ec48aed87